### PR TITLE
Movable interface to ab class hotfix

### DIFF
--- a/src/main/utilities/Movable.java
+++ b/src/main/utilities/Movable.java
@@ -1,5 +1,5 @@
 package main.utilities;
 
-public interface Movable {
+public class Movable {
 
 }


### PR DESCRIPTION
Cannot create a private field position of type Position inside an interface so switching to an abstract class with an abstract animate() method.

Closes #14 